### PR TITLE
Multiple assembly updates; ModelHelper ef model types dynamically imported and ActionMapper full AppDomain scan.

### DIFF
--- a/SapphireDb/Helper/ModelHelper.cs
+++ b/SapphireDb/Helper/ModelHelper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Newtonsoft.Json.Linq;
@@ -239,8 +240,9 @@ namespace SapphireDb.Helper
 
         public static IQueryable<object> GetValues(this SapphireDbContext db, KeyValuePair<Type, string> property)
         {
-            IQueryable<object> values = (IQueryable<object>) db.GetType().GetProperty(property.Value)?.GetValue(db);
-            return values?.AsNoTracking();
+            MethodInfo method = db.GetType().GetMethod((string)"Set", (int)(BindingFlags.Public | BindingFlags.Instance), Type.EmptyTypes); 
+            method = method.MakeGenericMethod(property.Key);
+            return ((IQueryable<object>)method.Invoke(db, null))?.AsNoTracking(); 
         }
 
         /// <summary>

--- a/SapphireDb/Internal/ActionMapper.cs
+++ b/SapphireDb/Internal/ActionMapper.cs
@@ -15,7 +15,7 @@ namespace SapphireDb.Internal
 
         public ActionMapper()
         {
-            actionHandlerTypes = Assembly.GetEntryAssembly()?.GetTypes()
+            actionHandlerTypes = (AppDomain.CurrentDomain.GetAssemblies().ToArray().SelectMany(x => x.GetTypes()))
                 .Where(t => typeof(ActionHandlerBase).IsAssignableFrom(t) && t.Name.EndsWith("Actions"))
                 .ToDictionary(t => t.Name.Substring(0, t.Name.LastIndexOf("Actions", StringComparison.Ordinal)).ToCamelCase(), t => t);
 


### PR DESCRIPTION
ModelHelper updates allow scenarios where ef model types are dynamically imported into the model schema rather than defined as closed generic properties on the dbcontext. ActionMapper updates allow scanning of mutilple assemblies in the app domain for action handlers